### PR TITLE
Use built-in script to check demo results.

### DIFF
--- a/runManifestDemo.sh
+++ b/runManifestDemo.sh
@@ -110,8 +110,8 @@ j=1
 NEWCOLUMNS=`for i in $COLUMNS; do echo -n "$j:$i "; j=$((j+1)); done`
 echo "Columns in benchmark datafile:"
 echo $NEWCOLUMNS
-echo "${LSSTSW}/lfs/bin/numdiff -# 11 detected-sources$SIZE_EXT.txt.expected detected-sources$SIZE_EXT.txt"
-${LSSTSW}/lfs/bin/numdiff -# 11 detected-sources$SIZE_EXT.txt.expected detected-sources$SIZE_EXT.txt
+echo "./bin/compare detected-sources${SIZE_EXT}.txt"
+./bin/compare detected-sources${SIZE_EXT}.txt
 if  [ $? != 0 ]; then
     print_error "*** Warning: output results not within error tolerance for: $DEMO_BASENAME"
     exit $BUILDBOT_WARNING


### PR DESCRIPTION
This provides a platform-independent call to numdiff.