### PR TITLE
enable devtoolset-[34] based on env vars

### DIFF
--- a/jenkins_wrapper.sh
+++ b/jenkins_wrapper.sh
@@ -56,11 +56,22 @@ if [[ $NO_FETCH == "true" ]]; then
   ARGS+=('--no-fetch')
 fi
 
-set -o verbose
-if grep -q -i "CentOS release 6" /etc/redhat-release 2>/dev/null; then
-  . /opt/rh/devtoolset-3/enable
-fi
-set +o verbose
+# shellcheck disable=SC2154
+case $compiler in
+  devtoolset-3)
+	set -o verbose
+	. /opt/rh/devtoolset-3/enable
+	set +o verbose
+	;;
+  devtoolset-4)
+    set -o verbose
+    . /opt/rh/devtoolset-4/enable
+    set +o verbose
+	;;
+  *)
+    echo "lp is on fire!"
+    ;;
+esac
 
 export LSSTSW=${LSSTSW:-$WORKSPACE/lsstsw}
 


### PR DESCRIPTION
Instead of unconditionally enabling devtoolset-3 when on el6, enable
devtoolset-[34] if the env vars DEVTOOLSET[34] have a true value.
