### PR TITLE
Add support for demo archive refs / running without lsstsw

### DIFF
--- a/lsstswBuild.sh
+++ b/lsstswBuild.sh
@@ -320,6 +320,10 @@ fi
 if [ $RUN_DEMO == "yes" ]; then
     start_section "demo"
 
+    # run demo script from the source checkout dir as it will download and
+    # unpack a tarball
+    cd "$LSSTSW_BUILD_DIR"
+
     print_info "Start Demo run at: $(date)"
     if ! "${SCRIPT_DIR}/runManifestDemo.sh" --tag "$TAG" --small; then
         error "*** There was an error running the simple integration demo."

--- a/runManifestDemo.sh
+++ b/runManifestDemo.sh
@@ -108,7 +108,7 @@ if ! tar xzf "$DEMO_TGZ"; then
     fail "*** Failed to unpack: ${DEMO_TGZ}"
 fi
 
-DEMO_BASENAME=$(basename "$DEMO_TGZ" | sed -e "s/\..*//")
+DEMO_BASENAME=$(basename "$DEMO_TGZ" | sed -e "s/\.tar\.gz$//")
 echo "DEMO_BASENAME: $DEMO_BASENAME"
 if [[ ! -d $DEMO_BASENAME ]]; then
     fail "*** Failed to find unpacked directory: ${DEMO_BASENAME}"

--- a/runManifestDemo.sh
+++ b/runManifestDemo.sh
@@ -6,8 +6,6 @@ set -e
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
 # shellcheck source=./settings.cfg.sh
 source "${SCRIPT_DIR}/settings.cfg.sh"
-# shellcheck source=../lsstsw/bin/setup.sh
-source "${LSSTSW}/bin/setup.sh"
 
 print_error() {
     >&2 echo -e "$@"
@@ -18,6 +16,10 @@ fail() {
     [[ -n $1 ]] && print_error "$1"
     # shellcheck disable=SC2086
     exit $code
+}
+
+setup() {
+    eval "$(eups_setup DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}" "$@")"
 }
 
 #--------------------------------------------------------------------------
@@ -71,8 +73,6 @@ for i; do
     esac
 done
 
-
-cd "$LSSTSW_BUILD_DIR"
 
 # Setup either requested tag or last successfully built lsst_apps
 if [[ -n $TAG ]]; then

--- a/runManifestDemo.sh
+++ b/runManifestDemo.sh
@@ -3,9 +3,10 @@
 
 set -e
 
-SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
-# shellcheck source=./settings.cfg.sh
-source "${SCRIPT_DIR}/settings.cfg.sh"
+# https://github.com/lsst/lsst_dm_stack_demo/archive/master.tar.gz
+DEMO_BASE_URL=${DEMO_BASE_URL:-https://github.com/lsst/lsst_dm_stack_demo/archive}
+# lsst_dm_stack_demo-master.tar.gz
+DEMO_BASE_DIR=${DEMO_BASE_DIR:-lsst_dm_stack_demo}
 
 print_error() {
     >&2 echo -e "$@"
@@ -19,7 +20,79 @@ fail() {
 }
 
 setup() {
+    # eval masks all errors
+    if ! type -p eups_setup; then
+        fail "unable to find eups_setup"
+    fi
     eval "$(eups_setup DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}" "$@")"
+}
+
+deeupsify_tag() {
+    local eups_tag=${1?eups_tag parameter is required}
+
+    # convert _ -> .
+    git_tag=${eups_tag//_/.}
+
+    # remove leading v
+    git_tag=${git_tag#v}
+
+    echo "$git_tag"
+}
+
+mk_archive_url() {
+    local ref=${1?ref parameter is required}
+
+    echo "${DEMO_BASE_URL}/${ref}.tar.gz"
+}
+
+mk_archive_dirname() {
+    local ref=${1?ref parameter is required}
+
+    echo "${DEMO_BASE_DIR}-${ref}"
+}
+
+mk_archive_filename() {
+    local ref=${1?ref parameter is required}
+
+    echo "$(mk_archive_dirname "$ref").tar.gz"
+}
+
+check_archive_ref() {
+    local ref=${1?ref parameter is required}
+
+    local url
+    url=$(mk_archive_url "$ref")
+    if curl -Ls --fail --head -o /dev/null "$url"; then
+        return 0
+    fi
+
+    return 1
+}
+
+find_archive_ref() {
+    local tag=$1
+
+    local ref
+    local -a candidate_refs
+
+    if [[ -n $tag ]]; then
+        candidate_refs=(
+            "$tag"
+            $(deeupsify_tag "$tag")
+        )
+    fi
+
+    candidate_refs+=( master )
+
+    for r in ${candidate_refs[*]}; do
+      [[ -z $r ]] && continue
+      if check_archive_ref "$r"; then
+          ref=$r
+          break
+      fi
+    done
+
+    echo "$ref"
 }
 
 #--------------------------------------------------------------------------
@@ -49,7 +122,6 @@ SIZE_EXT=""
 
 # shellcheck disable=SC2034
 options=$(getopt -l help,small,tag: -- "$@")
-
 for i; do
     case $i in
         --help)
@@ -74,6 +146,27 @@ for i; do
 done
 
 
+REF=$(find_archive_ref "$TAG")
+DEMO_TGZ=$(mk_archive_filename "$REF")
+DEMO_URL=$(mk_archive_url "$REF")
+DEMO_DIR=$(mk_archive_dirname "$REF")
+
+curl -kLo "$DEMO_TGZ" "$DEMO_URL"
+if [[ ! -f $DEMO_TGZ ]]; then
+    fail "*** Failed to acquire demo from: ${DEMO_URL}."
+fi
+
+echo "tar xzf ${DEMO_TGZ}"
+if ! tar xzf "$DEMO_TGZ"; then
+    fail "*** Failed to unpack: ${DEMO_TGZ}"
+fi
+
+if [[ ! -d $DEMO_DIR ]]; then
+    fail "*** Failed to find unpacked directory: ${DEMO_DIR}"
+fi
+
+cd "$DEMO_DIR"
+
 # Setup either requested tag or last successfully built lsst_apps
 if [[ -n $TAG ]]; then
     setup -t "$TAG" lsst_apps
@@ -95,26 +188,6 @@ echo "-----------------------------------------------------------------"
 if [[ -z $PIPE_TASKS_DIR || -z $OBS_SDSS_DIR ]]; then
     fail "*** Failed to setup either PIPE_TASKS or OBS_SDSS; both of  which are required by ${DEMO_BASENAME}"
 fi
-
-# Acquire and Load the demo package in buildbot work directory
-echo "curl -kLo ${DEMO_TGZ} ${DEMO_ROOT}"
-curl -kLo "$DEMO_TGZ" "$DEMO_ROOT"
-if [[ ! -f $DEMO_TGZ ]]; then
-    fail "*** Failed to acquire demo from: ${DEMO_ROOT}."
-fi
-
-echo "tar xzf $DEMO_TGZ"
-if ! tar xzf "$DEMO_TGZ"; then
-    fail "*** Failed to unpack: ${DEMO_TGZ}"
-fi
-
-DEMO_BASENAME=$(basename "$DEMO_TGZ" | sed -e "s/\.tar\.gz$//")
-echo "DEMO_BASENAME: $DEMO_BASENAME"
-if [[ ! -d $DEMO_BASENAME ]]; then
-    fail "*** Failed to find unpacked directory: ${DEMO_BASENAME}"
-fi
-
-cd "$DEMO_BASENAME"
 
 if ! ./bin/demo.sh --$SIZE; then
     fail "*** Failed during execution of ${DEMO_BASENAME}"

--- a/settings.cfg.sh
+++ b/settings.cfg.sh
@@ -14,10 +14,6 @@ DOC_REPO_URL=${DOC_REPO_URL:-"https://github.com/lsst/lsstDoxygen.git"}
 DOC_REPO_NAME=${DOC_REPO_NAME:-"lsstDoxygen"}
 DOC_REPO_DIR=${DOC_REPO_DIR:-"${LSSTSW_BUILD_DIR}/${DOC_REPO_NAME}"}
 
-# runManifestDemo.sh
-DEMO_ROOT=${DEMO_ROOT:-"https://github.com/lsst/lsst_dm_stack_demo/archive/master.tar.gz"}
-DEMO_TGZ=${DEMO_TGZ:-"lsst_dm_stack_demo-master.tar.gz"}
-
 # ansi color codes
 BLACK='\033[0;30m'
 DARK_GRAY='\033[1;30m'


### PR DESCRIPTION
Presently, `runManifestDemo.sh` is hardwired to download a archive of the
"demo" from the `master` branch.  The current `master` branch is incompatible
with past releases such as `v13_0`.  Machinery is being added to attempt to
find a ref (other than master) based on the specified tag.

Additionally, `runManifestDemo.sh` should now be able to run outside of an lsstsw based env.

based on top of #29