### PR TITLE
support explicit py 2/3 version setup

### DIFF
--- a/jenkins_wrapper.sh
+++ b/jenkins_wrapper.sh
@@ -88,8 +88,19 @@ fi
   OPTS=()
 
   # shellcheck disable=SC2154
-  if [[ $python == py3 ]]; then
-    OPTS+=('-3')
+  if [[ -n ${python+1} ]]; then
+    case $python in
+      py2)
+        OPTS+=('-2')
+        ;;
+      py3)
+        OPTS+=('-3')
+        ;;
+      *)
+        >&2 echo "unsupported python version: $python"
+        exit 1
+        ;;
+    esac
   fi
 
   # shellcheck disable=SC2154


### PR DESCRIPTION
Previously, only py3 would be explicitly requested from lsstsw's deploy
script based on env vars.  As py3 is now the default, explicit support
for requesting py2 is now needed.