### PR TITLE
do not set --print-fail flag on lsstswBuild.sh

### DIFF
--- a/jenkins_wrapper.sh
+++ b/jenkins_wrapper.sh
@@ -41,7 +41,6 @@ if [[ $SKIP_DOCS == true ]]; then
   ARGS+=('--skip_docs')
 fi
 
-ARGS+=('--print-fail')
 ARGS+=('--color')
 
 if [[ $SKIP_DEMO == true ]]; then


### PR DESCRIPTION
Instead, jenkins will artifact the .log files for end-users to
optionally inspect.