### PR TITLE
remove usage of eval for indirect variables

### DIFF
--- a/create_xlinkdocs.sh
+++ b/create_xlinkdocs.sh
@@ -96,7 +96,7 @@ settings=(
 
 for i in ${settings[*]}
 do
-  eval echo "${i}: \$$i"
+  echo "${i}: ${!i}"
 done
 
 if ! ( set -e

--- a/lsstswBuild.sh
+++ b/lsstswBuild.sh
@@ -191,7 +191,7 @@ settings=(
 set_color "$LIGHT_CYAN"
 for i in ${settings[*]}
 do
-  eval echo "${i}: \$$i"
+  echo "${i}: ${!i}"
 done
 no_color
 


### PR DESCRIPTION
Replaced with bash ${!...} syntax.