### PR TITLE
DM-55655: pin CONDA_OVERRIDE_GLIBC=2.17 during ./bin/deploy

### DIFF
--- a/jenkins_wrapper.sh
+++ b/jenkins_wrapper.sh
@@ -92,6 +92,16 @@ if [[ $LSST_DEPLOY_MODE == bleed ]]; then
   OPTS+=('-b')
 fi
 
+# Force the conda solver to target glibc 2.17 so the rebuild's conda env
+# (captured in stack/src/env/<tag>.env via `conda list --explicit`) resolves
+# packages that run on RHEL7-era hosts such as USDF cvmfs. Only affects the
+# env create/install done by ./bin/deploy; unset before the build runs so it
+# never influences runtime. Linux/x86_64 only -- irrelevant on macOS, and we
+# don't override glibc on aarch64.
+if [[ $(uname -s) == Linux && $(uname -m) == x86_64 ]]; then
+  export CONDA_OVERRIDE_GLIBC=2.17
+fi
+
 if [[ -z "$RUBINENV_ORG_FORK" ]]; then
   # The LSST_SPLENV_REF can refer to a rubin-env version
   #  or to an old scipipe_conda_env SHA1
@@ -115,6 +125,9 @@ else
   ./bin/set_prereleased_env "$RUBINENV_ORG_FORK" "$RUBINENV_BRANCH"
   LSST_CONDA_ENV_NAME="$(cat rubinenv-feedstock/env.name)"
 fi
+
+# glibc override applies only to the env-create step above, never at build/runtime
+unset CONDA_OVERRIDE_GLIBC
 
 export LSST_CONDA_ENV_NAME
 

--- a/jenkins_wrapper.sh
+++ b/jenkins_wrapper.sh
@@ -43,6 +43,7 @@ LSST_DEPLOY_MODE=${LSST_DEPLOY_MODE:-}
 LSST_NO_FETCH=${LSST_NO_FETCH:-false}
 LSST_NO_BINARY_FETCH=${LSST_NO_BINARY_FETCH:-true}
 LSST_PREP_ONLY=${LSST_PREP_ONLY:-false}
+LSST_GLIBC_FLAG=${LSST_GLIBC_FLAG:-false}
 LSST_REFS=${LSST_REFS:-}
 
 fatal_vars() {
@@ -97,8 +98,9 @@ fi
 # packages that run on RHEL7-era hosts such as USDF cvmfs. Only affects the
 # env create/install done by ./bin/deploy; unset before the build runs so it
 # never influences runtime. Linux/x86_64 only -- irrelevant on macOS, and we
-# don't override glibc on aarch64.
-if [[ $(uname -s) == Linux && $(uname -m) == x86_64 ]] && \
+# don't override glibc on aarch64. We also need to pass a flag from Jenkins to
+# avoid false possitives.
+if [[ $LSST_GLIBC_FLAG = "true" && $(uname -s) == Linux && $(uname -m) == x86_64 ]] && \
   [[ $(printf '%s\n' "13.0.0" "$LSST_SPLENV_REF" | sort -V | tail -n1) == "$LSST_SPLENV_REF" ]]; then
   export CONDA_OVERRIDE_GLIBC=2.17
 fi

--- a/jenkins_wrapper.sh
+++ b/jenkins_wrapper.sh
@@ -99,7 +99,7 @@ fi
 # env create/install done by ./bin/deploy; unset before the build runs so it
 # never influences runtime. Linux/x86_64 only -- irrelevant on macOS, and we
 # don't override glibc on aarch64. We also need to pass a flag from Jenkins to
-# avoid false possitives.
+# avoid false positives.
 if [[ $LSST_GLIBC_FLAG = "true" && $(uname -s) == Linux && $(uname -m) == x86_64 ]] && \
   [[ $(printf '%s\n' "13.0.0" "$LSST_SPLENV_REF" | sort -V | tail -n1) == "$LSST_SPLENV_REF" ]]; then
   export CONDA_OVERRIDE_GLIBC=2.17

--- a/jenkins_wrapper.sh
+++ b/jenkins_wrapper.sh
@@ -98,7 +98,8 @@ fi
 # env create/install done by ./bin/deploy; unset before the build runs so it
 # never influences runtime. Linux/x86_64 only -- irrelevant on macOS, and we
 # don't override glibc on aarch64.
-if [[ $(uname -s) == Linux && $(uname -m) == x86_64 ]]; then
+if [[ $(uname -s) == Linux && $(uname -m) == x86_64 ]] && \
+  [[ $(printf '%s\n' "13.0.0" "$LSST_SPLENV_REF" | sort -V | tail -n1) == "$LSST_SPLENV_REF" ]]; then
   export CONDA_OVERRIDE_GLIBC=2.17
 fi
 


### PR DESCRIPTION
Force the conda solver to target glibc 2.17 while ./bin/deploy creates the rebuild's conda env, so the env captured in stack/src/env/<tag>.env resolves glibc-2.17-compatible packages that run on RHEL7-era hosts such as USDF cvmfs. Scoped to linux/x86_64 and unset before the build runs, so it never affects runtime, aarch64, or macOS. This will only run if we set the flag, are running on a version greater than 13.0 and it is on linux x86 
